### PR TITLE
Persists events on create

### DIFF
--- a/lib/land/tracker.rb
+++ b/lib/land/tracker.rb
@@ -125,6 +125,7 @@ module Land
 
       Event.new(visit_id: @visit_id, event_type: type, meta: meta).tap do |event|
         @events << event
+        event.save!
       end
     end
 


### PR DESCRIPTION
Trello: https://trello.com/c/qDM0bHPt/590-change-landtrackercreateevent-to-actually-create-the-event-in-the-db